### PR TITLE
change the maximum bucket name length to 16.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,40 +84,39 @@ Usage of ./oval:
 
 ```
 $ ./oval -size 4k-16k --time 5 -num_obj 1000 -num_worker 4 -bucket test-bucket -endpoint http://localhost:9000
-Worker ID = 0xb67f, Key = [ov0000000000, ov0000000249]
-Worker ID = 0xb680, Key = [ov0000000250, ov0000000499]
-Worker ID = 0xb681, Key = [ov0000000500, ov0000000749]
-Worker ID = 0xb682, Key = [ov0000000750, ov0000000999]
+Worker ID = 0xface, Key = [ov0000000000, ov0000000249]
+Worker ID = 0xfacf, Key = [ov0000000250, ov0000000499]
+Worker ID = 0xfad0, Key = [ov0000000500, ov0000000749]
+Worker ID = 0xfad1, Key = [ov0000000750, ov0000000999]
 Validation start.
 Validation finished.
 Statistics report.
-put count: 515
-get count: 499
-get (for validation) count: 992
-delete count: 465
+put count: 726
+get count: 635
+get (for validation) count: 1395
+delete count: 648
 ```
 
 #### Data corruption case
 
 ```
 $ ./oval -size 4k-16k --time 5 -num_obj 1000 -num_worker 4 -bucket test-bucket -endpoint http://localhost:9000
-Worker ID = 0x790a, Key = [ov0000000000, ov0000000249]
-Worker ID = 0x790b, Key = [ov0000000250, ov0000000499]
-Worker ID = 0x790c, Key = [ov0000000500, ov0000000749]
-Worker ID = 0x790d, Key = [ov0000000750, ov0000000999]
+Worker ID = 0xe628, Key = [ov0000000000, ov0000000249]
+Worker ID = 0xe629, Key = [ov0000000250, ov0000000499]
+Worker ID = 0xe62a, Key = [ov0000000500, ov0000000749]
+Worker ID = 0xe62b, Key = [ov0000000750, ov0000000999]
 Validation start.
 worker.go:91: Data validation error occurred after put.
 WriteCount is wrong. (expected = "2", actual = "1")
-00000000  74 65 73 74 2d 62 75 63  6b 65 74 20 6f 76 30 30  |test-bucket ov00|
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bucket name
-                                               ^^^^^^^^^^^
-00000010  30 30 30 30 30 33 35 33  01 00 00 00 00 00 00 00  |00000353........|
-          ^^^^^^^^^^^^^^^^^^^^^^^ key name
-                                   ^^^^^^^^^^^ write count
-                                               ^^^^^^^^^^^ byte offset in this object
-00000020  3c 62 f8 50 c6 eb 05 00  0b 79 00 00 2c 2d 2e 2f  |<b.P.....y..,-./|
-          ^^^^^^^^^^^^^^^^^^^^^^^ unix time (micro sec)
-                                   ^^^^^^^^^^^ worker ID
+00000000  74 65 73 74 2d 62 75 63  6b 65 74 20 20 20 20 20  |test-bucket     |
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bucket name
+00000010  6f 76 30 30 30 30 30 30  30 36 36 37 01 00 00 00  |ov0000000667....|
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ key name
+                                               ^^^^^^^^^^^ write count
+00000020  00 00 00 00 2a e6 00 00  f5 c6 f1 69 e5 ed 05 00  |....*......i....|
+          ^^^^^^^^^^^ byte offset in this object
+                      ^^^^^^^^^^^ worker ID
+                                   ^^^^^^^^^^^^^^^^^^^^^^^ unix time (micro sec)
 00000030  30 31 32 33 34 35 36 37  38 39 3a 3b 3c 3d 3e 3f  |0123456789:;<=>?|
 00000040  40 41 42 43 44 45 46 47  48 49 4a 4b 4c 4d 4e 4f  |@ABCDEFGHIJKLMNO|
 00000050  50 51 52 53 54 55 56 57  58 59 5a 5b 5c 5d 5e 5f  |PQRSTUVWXYZ[\]^_|

--- a/object/object.go
+++ b/object/object.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	MAX_BUCKET_NAME_LENGTH = 12
+	MAX_BUCKET_NAME_LENGTH = 16
 	MAX_KEY_LENGTH         = 12
 )
 

--- a/pattern/pattern.go
+++ b/pattern/pattern.go
@@ -29,6 +29,9 @@ func Generate(minSize, maxSize, workerID int, bucketName string, obj *object.Obj
 	if maxSize < minSize {
 		return nil, 0, errors.New("maxSize should be larger than minSize.")
 	}
+	if len(bucketName) > object.MAX_BUCKET_NAME_LENGTH {
+		bucketName = bucketName[:object.MAX_BUCKET_NAME_LENGTH]
+	}
 
 	var dataSize int
 	dataSize = minSize + dataUnitSize*rand.Intn((maxSize-minSize)/dataUnitSize+1)
@@ -63,7 +66,7 @@ func generateDataUnit(unitCount, workerID int, bucketName string, obj *object.Ob
 		return err
 	}
 	if n != object.MAX_BUCKET_NAME_LENGTH+object.MAX_KEY_LENGTH {
-		return errors.New("bucket name and key was not written correctly.")
+		return fmt.Errorf("bucket name and key was not written correctly. n = %d", n)
 	}
 
 	numBinBuf := make([]byte, dataUnitHeaderSizeWithoutBucketAndKey)
@@ -91,6 +94,9 @@ func generateDataUnit(unitCount, workerID int, bucketName string, obj *object.Ob
 }
 
 func Valid(workerID int, expectedBucketName string, obj *object.Object, reader io.Reader) error {
+	if len(expectedBucketName) > object.MAX_BUCKET_NAME_LENGTH {
+		expectedBucketName = expectedBucketName[:object.MAX_BUCKET_NAME_LENGTH]
+	}
 	data := make([]byte, dataUnitSize)
 	for i := 0; i < obj.Size/dataUnitSize; i++ {
 		n, _ := io.ReadFull(reader, data)

--- a/pattern/pattern_test.go
+++ b/pattern/pattern_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	testBucketName = "test-bucket"
-	testKeyName    = "test-key"
+	testBucketName     = "test-bucket"
+	testLongBucketName = "test-long-long-long-bucket"
+	testKeyName        = "test-key"
 )
 
 /*******************************/
@@ -110,6 +111,56 @@ func (suite *GeneratorSuite) TestGenerateSuccess() {
 	suite.Equal([]byte{0x64, 0x00, 0x00, 0x00}, data[current:current+4]) // hex(100) = 0x64
 }
 
+func (suite *GeneratorSuite) TestGenerateLongBucketName() {
+	obj := &object.Object{
+		Key:        testKeyName,
+		Size:       256,
+		WriteCount: 300,
+	}
+	workerID := 100
+
+	readSeeker, size, err := Generate(512, 512, workerID, testLongBucketName, obj)
+	suite.NoError(err)
+	suite.Equal(512, size)
+	data, err := io.ReadAll(readSeeker)
+	suite.NoError(err)
+
+	// 1st data unit
+	// bucketName
+	suite.Equal(append([]byte(testLongBucketName[:object.MAX_BUCKET_NAME_LENGTH])),
+		data[0:object.MAX_BUCKET_NAME_LENGTH])
+	current := object.MAX_BUCKET_NAME_LENGTH
+	// keyName
+	suite.Equal(append([]byte(testKeyName), 0x20, 0x20, 0x20, 0x20), data[current:current+object.MAX_KEY_LENGTH])
+	current += object.MAX_KEY_LENGTH
+	// Check write count
+	suite.Equal([]byte{0x2c, 0x01, 0x00, 0x00}, data[current:current+4]) // hex(300) = 0x12c
+	current += 4
+	// Check offset
+	suite.Equal([]byte{0x00, 0x00, 0x00, 0x00}, data[current:current+4])
+	current += 4
+	// Check worker ID
+	suite.Equal([]byte{0x64, 0x00, 0x00, 0x00}, data[current:current+4]) // hex(100) = 0x64
+
+	// 2nd data unit
+	current = dataUnitSize
+	// bucketName
+	suite.Equal(append([]byte(testLongBucketName[:object.MAX_BUCKET_NAME_LENGTH])),
+		data[current:current+object.MAX_BUCKET_NAME_LENGTH])
+	current += object.MAX_BUCKET_NAME_LENGTH
+	// keyName
+	suite.Equal(append([]byte(testKeyName), 0x20, 0x20, 0x20, 0x20), data[current:current+object.MAX_KEY_LENGTH])
+	current += object.MAX_KEY_LENGTH
+	// Check write count
+	suite.Equal([]byte{0x2c, 0x01, 0x00, 0x00}, data[current:current+4]) // hex(300) = 0x12c
+	current += 4
+	// Check offset
+	suite.Equal([]byte{0x00, 0x01, 0x00, 0x00}, data[current:current+4]) // hex(256*1) = 0x100
+	current += 4
+	// Check worker ID
+	suite.Equal([]byte{0x64, 0x00, 0x00, 0x00}, data[current:current+4]) // hex(100) = 0x64
+}
+
 func (suite *GeneratorSuite) TestValidDataUnitSuccess() {
 	obj := &object.Object{
 		Key:        testKeyName,
@@ -139,6 +190,21 @@ func (suite *GeneratorSuite) TestValidSuccess() {
 	obj.Size = size
 
 	err = Valid(workerID, testBucketName, obj, readSeeker)
+	suite.NoError(err)
+}
+
+func (suite *GeneratorSuite) TestValidLongBucketName() {
+	obj := &object.Object{
+		Key:        testKeyName,
+		WriteCount: 300,
+	}
+	workerID := 100
+
+	readSeeker, size, err := Generate(1024, 1024, workerID, testLongBucketName, obj)
+	suite.NoError(err)
+	obj.Size = size
+
+	err = Valid(workerID, testLongBucketName, obj, readSeeker)
 	suite.NoError(err)
 }
 

--- a/pattern/pattern_test.go
+++ b/pattern/pattern_test.go
@@ -44,7 +44,8 @@ func (suite *GeneratorSuite) TestGenerateDataUnitSuccess() {
 	suite.Equal(dataUnitSize, len(data))
 
 	// bucketName
-	suite.Equal(append([]byte(testBucketName), 0x20), data[0:object.MAX_BUCKET_NAME_LENGTH])
+	suite.Equal(append([]byte(testBucketName), 0x20, 0x20, 0x20, 0x20, 0x20),
+		data[0:object.MAX_BUCKET_NAME_LENGTH])
 	current := object.MAX_BUCKET_NAME_LENGTH
 	// keyName
 	suite.Equal(append([]byte(testKeyName), 0x20, 0x20, 0x20, 0x20), data[current:current+object.MAX_KEY_LENGTH])
@@ -55,8 +56,7 @@ func (suite *GeneratorSuite) TestGenerateDataUnitSuccess() {
 	// Check offset
 	suite.Equal([]byte{0x00, 0x04, 0x00, 0x00}, data[current:current+4]) // hex(256*4) = 0x400
 	current += 4
-	current += 8 // Skip unix time area
-	// Check offset
+	// Check worker ID
 	suite.Equal([]byte{0x64, 0x00, 0x00, 0x00}, data[current:current+4]) // hex(100) = 0x64
 }
 
@@ -76,7 +76,8 @@ func (suite *GeneratorSuite) TestGenerateSuccess() {
 
 	// 1st data unit
 	// bucketName
-	suite.Equal(append([]byte(testBucketName), 0x20), data[0:object.MAX_BUCKET_NAME_LENGTH])
+	suite.Equal(append([]byte(testBucketName), 0x20, 0x20, 0x20, 0x20, 0x20),
+		data[0:object.MAX_BUCKET_NAME_LENGTH])
 	current := object.MAX_BUCKET_NAME_LENGTH
 	// keyName
 	suite.Equal(append([]byte(testKeyName), 0x20, 0x20, 0x20, 0x20), data[current:current+object.MAX_KEY_LENGTH])
@@ -87,14 +88,14 @@ func (suite *GeneratorSuite) TestGenerateSuccess() {
 	// Check offset
 	suite.Equal([]byte{0x00, 0x00, 0x00, 0x00}, data[current:current+4])
 	current += 4
-	current += 8 // Skip unix time area
-	// Check offset
+	// Check worker ID
 	suite.Equal([]byte{0x64, 0x00, 0x00, 0x00}, data[current:current+4]) // hex(100) = 0x64
 
 	// 2nd data unit
 	current = dataUnitSize
 	// bucketName
-	suite.Equal(append([]byte(testBucketName), 0x20), data[current:current+object.MAX_BUCKET_NAME_LENGTH])
+	suite.Equal(append([]byte(testBucketName), 0x20, 0x20, 0x20, 0x20, 0x20),
+		data[current:current+object.MAX_BUCKET_NAME_LENGTH])
 	current += object.MAX_BUCKET_NAME_LENGTH
 	// keyName
 	suite.Equal(append([]byte(testKeyName), 0x20, 0x20, 0x20, 0x20), data[current:current+object.MAX_KEY_LENGTH])
@@ -105,8 +106,7 @@ func (suite *GeneratorSuite) TestGenerateSuccess() {
 	// Check offset
 	suite.Equal([]byte{0x00, 0x01, 0x00, 0x00}, data[current:current+4]) // hex(256*1) = 0x100
 	current += 4
-	current += 8 // Skip unix time area
-	// Check offset
+	// Check worker ID
 	suite.Equal([]byte{0x64, 0x00, 0x00, 0x00}, data[current:current+4]) // hex(100) = 0x64
 }
 


### PR DESCRIPTION
By this change, it became hard to read the data validation error report. I fixed this problem by reordering the items in the object data.

Signed-off-by: Shinya Hayashi <shinyaUT0925@gmail.com>